### PR TITLE
Use cl-letf instead of flet

### DIFF
--- a/term+.el
+++ b/term+.el
@@ -4,6 +4,7 @@
 ;; URL: https://github.com/tarao/term-plus-el
 ;; Version: 0.1
 ;; Keywords: terminal, emulation
+;; Package-Requires: ((emacs "24") (cl-lib "0.5"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/xterm-256color.el
+++ b/xterm-256color.el
@@ -25,7 +25,7 @@
 ;;; Code:
 
 (require 'term)
-(eval-when-compile (require 'cl))
+(require 'cl-lib)
 
 (setq term-term-name "xterm-256color")
 (when (and (featurep 'term+) (fboundp 'term+new-protocol))
@@ -444,7 +444,8 @@ erase from home to point; else erase from home to point-max."
 (defadvice term-insert-lines (around xterm-insert-lines activate)
   "Fill lines if the current color is not the default color."
   (if (term-need-filling)
-      (flet ((term-insert-char (char count) (term-fill-lines count)))
+      (cl-letf ((symbol-function 'term-insert-char)
+                (lambda (char count) (term-fill-lines count)))
         ad-do-it)
     ad-do-it))
 (defadvice term-delete-chars (around xterm-delete-char activate)


### PR DESCRIPTION
Display warnings in `*Compile-Log*` buffer.

```
Warning (bytecomp): reference to free variable ‘term-vertical-motion’
Warning (bytecomp): ‘flet’ is an obsolete macro (as of 24.3); use either ‘cl-flet’ or ‘cl-letf’.
Warning (bytecomp): reference to free variable ‘term-terminal-parameter’
Warning (bytecomp): reference to free variable ‘term-scroll-end’
Warning (bytecomp): reference to free variable ‘term-width’
```

My environment is `GNU Emacs 25.1.1 (x86_64-apple-darwin15.5.0, NS appkit-1404.47 Version 10.11.5 (Build 15F34)) of 2016-07-27`.
